### PR TITLE
[ FEAT ] Change elasticutil to accept custom queries

### DIFF
--- a/entities.go
+++ b/entities.go
@@ -1,6 +1,10 @@
 package elasticutil
 
-import "time"
+import (
+	"time"
+
+	"github.com/olivere/elastic/v7"
+)
 
 type Ranges interface {
 	time.Time | uint64 | float64
@@ -52,4 +56,17 @@ type FullTextSearchShould struct {
 // NewFullTextSearchShould creates a FullTextSearchShould struct with the given payload.
 func NewFullTextSearchShould(payload interface{}) FullTextSearchShould {
 	return FullTextSearchShould{payload}
+}
+
+// CustomSearch is the struct that contains the CustomQuery function.
+type CustomSearch struct {
+	GetQuery CustomQuery
+}
+
+// CustomQuery is the type function that will return the custom query.
+type CustomQuery func() (*elastic.BoolQuery, error)
+
+// NewCustomSearch creates a CustomSearch struct with the given CustomQuery function.
+func NewCustomSearch(query CustomQuery) CustomSearch {
+	return CustomSearch{query}
 }

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -99,7 +99,7 @@ func MarshalQuery(query elastic.Query) string {
 	return ""
 }
 
-// nolint: funlen, cyclop, gocognit
+//nolint: funlen, cyclop, gocognit
 func getMustQuery(
 	ctx context.Context,
 	filter interface{},
@@ -189,6 +189,12 @@ func getMustQuery(
 					return nil, errors.E(op, err)
 				}
 				queries = append(queries, boolQuery)
+			case CustomSearch:
+				boolQuery, err := v.GetQuery()
+				if err != nil {
+					return nil, errors.E(op, err)
+				}
+				queries = append(queries, boolQuery)
 			default:
 				return nil, errors.E(op, structNotSupportedError(names[0]))
 			}
@@ -200,7 +206,7 @@ func getMustQuery(
 	return queries, nil
 }
 
-// nolint: funlen, cyclop
+//nolint: funlen, cyclop
 func getExistsQuery(
 	filter interface{},
 ) (existsQueries, notExistsQueries []elastic.Query, err error) {

--- a/response.go
+++ b/response.go
@@ -28,7 +28,7 @@ func AllShardsMustReplyOnElasticSearch(
 }
 
 // GetErrorFromElasticResponse checks if err is an *elastic.Error and returns an error with a formatted message.
-// nolint: gocritic, errorlint
+//nolint: gocritic, errorlint
 func GetErrorFromElasticResponse(err error) error {
 	switch e := err.(type) {
 	case *elastic.Error:

--- a/response_test.go
+++ b/response_test.go
@@ -1,4 +1,4 @@
-// nolint
+//nolint
 package elasticutil
 
 import (


### PR DESCRIPTION
Problema:

Currently ElasticUtil does not allow custom queries, so it does not serve certain use cases.

Solução:

Creates a Custom type, represented by the CustomSearch structure that receives a function that allows custom queries