### PR TITLE
feat: Add aggregation support to search function

### DIFF
--- a/examples/official/aggregations.go
+++ b/examples/official/aggregations.go
@@ -1,0 +1,66 @@
+package main
+
+import elasticutil "github.com/arquivei/elasticutil/official/v7"
+
+func createAggregations() elasticutil.RequestAggregation {
+	return elasticutil.RequestAggregation{
+		Metrics: []elasticutil.RequestMetricAggregation{
+			{
+				Name:  "sum_aggregation_name",
+				Type:  "sum",
+				Field: "sum_field",
+			},
+			{
+				Name:  "max_aggregation_name",
+				Type:  "max",
+				Field: "max_field",
+			},
+			{
+				Name:  "max_aggregation_name_2",
+				Type:  "max",
+				Field: "max_field_2",
+			},
+			{
+				Name:  "min_aggregation_name",
+				Type:  "min",
+				Field: "min_field",
+			},
+			{
+				Name:  "count_aggregation",
+				Type:  "count",
+				Field: "count_field",
+			},
+		},
+		Buckets: []elasticutil.RequestBucketAggregation{
+			{
+				Name:  "some_term_agg",
+				Field: "CompanyRole",
+				Type:  "term",
+				MetricsSubAgg: []elasticutil.RequestMetricAggregation{
+					{
+						Name:  "min_agg_in_term_name",
+						Field: "min_in_term_field",
+						Type:  "min",
+					},
+				},
+			},
+			{
+				Name:  "some_histogram_agg",
+				Field: "EmissionDate",
+				Type:  "monthlyhistogram",
+				MetricsSubAgg: []elasticutil.RequestMetricAggregation{
+					{
+						Name:  "max_agg_in_histogram_name",
+						Field: "max_in_histogram_field",
+						Type:  "max",
+					},
+					{
+						Name:  "min_agg_in_histogram_name",
+						Field: "min_in_histogram_field",
+						Type:  "min",
+					},
+				},
+			},
+		},
+	}
+}

--- a/examples/official/main.go
+++ b/examples/official/main.go
@@ -28,6 +28,7 @@ func main() {
 				},
 			},
 			SearchAfter: "",
+			Aggregation: createAggregations(),
 		},
 	)
 

--- a/official/v7/entity_aggregation.go
+++ b/official/v7/entity_aggregation.go
@@ -1,0 +1,24 @@
+package v7
+
+// RequestAggregation contains all the aggregations that will be requested to elastic search
+// This struct will be transformed in an elastic query
+type RequestAggregation struct {
+	Metrics []RequestMetricAggregation
+	Buckets []RequestBucketAggregation
+}
+
+// RequestMetricAggregation is an aggregation that computes metrics over a set of documents
+type RequestMetricAggregation struct {
+	Name  string
+	Type  string
+	Field string
+}
+
+// RequestBucketAggregation is a aggregation that groups documents using either a histogram or a terms search.
+// It can contains a metrics aggregation that will compute metrics over all documents inside a bucket
+type RequestBucketAggregation struct {
+	Name          string
+	Type          string
+	Field         string
+	MetricsSubAgg []RequestMetricAggregation
+}

--- a/official/v7/entity_errors.go
+++ b/official/v7/entity_errors.go
@@ -46,3 +46,7 @@ func fullTextSearchTypeNotSupported(name string) error {
 func multiMatchSearchTypeNotSupported(name string) error {
 	return errors.New("[" + name + "] multi match search value is not supported")
 }
+
+func aggregationTypeNotSupported(t string) error {
+	return errors.New("aggregation type is not supported: " + t)
+}

--- a/official/v7/entity_filter.go
+++ b/official/v7/entity_filter.go
@@ -6,7 +6,7 @@ import (
 	"github.com/arquivei/elasticutil/official/v7/querybuilders"
 )
 
-// Filter is a struct that eill be transformed in a olivere/elastic's query.
+// Filter is a struct that will be transformed in a olivere/elastic's query.
 //
 // "Must" and "MustNot" is for the terms, range and multi match query.
 // "Exists" is for the exists query.

--- a/official/v7/querybuilders/search_queries_aggs.go
+++ b/official/v7/querybuilders/search_queries_aggs.go
@@ -1,0 +1,127 @@
+package querybuilders
+
+// AggsQuery is used to build an aggregation elastic query
+// For more details, see:
+// https://www.elastic.co/guide/en/elasticsearch/reference/7.0/search-aggregations.html
+type AggsQuery struct {
+	metricAggs              []MetricAggregation
+	bucketTermsAggs         []BucketTermsAggregation
+	bucketDateHistogramAggs []BucketDateHistogramAggregation
+}
+
+// Creates a new aggs query with empty aggregations lists
+func NewAggsQuery() *AggsQuery {
+	return &AggsQuery{
+		metricAggs:              make([]MetricAggregation, 0),
+		bucketTermsAggs:         make([]BucketTermsAggregation, 0),
+		bucketDateHistogramAggs: make([]BucketDateHistogramAggregation, 0),
+	}
+}
+
+// BucketTerms appends a MetricAggregation list to the metricAggs field
+func (q *AggsQuery) Metric(aggs ...MetricAggregation) *AggsQuery {
+	q.metricAggs = append(q.metricAggs, aggs...)
+	return q
+}
+
+// BucketTerms appends a BucketTermsAggregation list to the bucketTermsAggs field
+func (q *AggsQuery) BucketTerms(aggs ...BucketTermsAggregation) *AggsQuery {
+	q.bucketTermsAggs = append(q.bucketTermsAggs, aggs...)
+	return q
+}
+
+// BucketDateHistogram appends a BucketDateHistogramAggregation list to the bucketDateHistogramAggs field
+func (q *AggsQuery) BucketDateHistogram(aggs ...BucketDateHistogramAggregation) *AggsQuery {
+	q.bucketDateHistogramAggs = append(q.bucketDateHistogramAggs, aggs...)
+	return q
+}
+
+// Source is a helper function used to build elastic query
+// it returns a map that can be marshalled into json string
+func (q *AggsQuery) Source() (interface{}, error) {
+	// This is the output of the source function:
+	// It returns the json string that can be used in elastic query
+	// {
+	//     "sum_agg_name": {
+	//         "sum": {
+	//             "field": "field_name"
+	//         }
+	//     },
+	//     "min_agg_name": {
+	//         "min": {
+	//             "field": "field_name"
+	//         }
+	//     },
+	//     "max_agg_name": {
+	//         "max": {
+	//             "field": "field_name"
+	//         }
+	//     },
+	//     "count_agg_name": {
+	//         "value_count": {
+	//             "field": "field_name"
+	//         }
+	//     },
+	//     "bucket_histogram_name": {
+	//         "date_histogram": {
+	//             "field": "EmissionDate",
+	//             "interval": "month",
+	//             "min_doc_count": 300
+	//         },
+	//         "aggs": {
+	//             "max_agg_inside_bucket_histogram_name": {
+	//                 "max": {
+	//                     "field": "field_name"
+	//                 }
+	//             },
+	//             "min_agg_inside_bucket_histogram_name": {
+	//                 "min": {
+	//                     "field": "field_name"
+	//                 }
+	//             }
+	//         }
+	//     },
+	//     "bucket_term_name": {
+	//         "terms": {
+	//             "field": "field_name",
+	//             "size": 10,
+	//             "show_term_doc_count_error": true
+	//         },
+	//         "aggs": {
+	//             "sum_agg_inside_bucket_term_name": {
+	//                 "sum": {
+	//                     "field": "field_name"
+	//                 }
+	//             }
+	//         }
+	//     }
+	// }
+
+	aggs := make(map[string]interface{})
+
+	for _, metricAgg := range q.metricAggs {
+		src, err := metricAgg.Source()
+		if err != nil {
+			return nil, err
+		}
+		aggs[metricAgg.name] = src
+	}
+
+	for _, bucketTermsAgg := range q.bucketTermsAggs {
+		src, err := bucketTermsAgg.Source()
+		if err != nil {
+			return nil, err
+		}
+		aggs[bucketTermsAgg.name] = src
+	}
+
+	for _, bucketHistogramAggs := range q.bucketDateHistogramAggs {
+		src, err := bucketHistogramAggs.Source()
+		if err != nil {
+			return nil, err
+		}
+		aggs[bucketHistogramAggs.name] = src
+	}
+
+	return aggs, nil
+}

--- a/official/v7/querybuilders/search_queries_aggs_bucket_datehistogram.go
+++ b/official/v7/querybuilders/search_queries_aggs_bucket_datehistogram.go
@@ -1,0 +1,91 @@
+package querybuilders
+
+// BucketDateHistogramAggregation is a multi-bucket values source based aggregation
+// that can be applied on date values extracted from the documents.
+// It dynamically builds fixed size (a.k.a. interval) buckets over the
+// values.
+// See: https://www.elastic.co/guide/en/elasticsearch/reference/7.0/search-aggregations-bucket-datehistogram-aggregation.html
+type BucketDateHistogramAggregation struct {
+	name                   string
+	field                  string
+	subMetricsAggregations []MetricAggregation
+	interval               string
+	minDocCount            *int //optional
+}
+
+// NewBucketHistogramAggregation returns a pointer to a new BucketDateHistogramAggregation
+// with an empty subMetricsAggregations list
+func NewBucketHistogramAggregation(name, field, interval string) *BucketDateHistogramAggregation {
+	return &BucketDateHistogramAggregation{
+		name:                   name,
+		field:                  field,
+		interval:               interval,
+		subMetricsAggregations: make([]MetricAggregation, 0),
+	}
+}
+
+// SubMetrics appends a MetricAggregation list to the subMetricsAggregations field
+func (a *BucketDateHistogramAggregation) SubMetrics(
+	agg ...MetricAggregation,
+) *BucketDateHistogramAggregation {
+	a.subMetricsAggregations = append(a.subMetricsAggregations, agg...)
+	return a
+}
+
+// MinDocCount sets the minimum document count per bucket.
+// Buckets with less documents than this min value will not be returned.
+func (a *BucketDateHistogramAggregation) MinDocCount(minDocCount int) *BucketDateHistogramAggregation {
+	a.minDocCount = &minDocCount
+	return a
+}
+
+// Source is a helper function used to build elastic query
+// it returns a map that can be marshalled into json string
+func (a *BucketDateHistogramAggregation) Source() (interface{}, error) {
+	// This is the output of the source function:
+	// It returns the json string that can be used in elastic query
+	// Example:
+	// {
+	//     "aggs" : {
+	//         "articles_over_time" : {
+	//             "date_histogram" : {
+	//                 "field" : "date",
+	//                 "interval" : "month"
+	//             }
+	//         }
+	//     }
+	// }
+	//
+	// This method returns only the { "date_histogram" : { ... } } part.
+
+	source := make(map[string]interface{})
+	opts := make(map[string]interface{})
+
+	// date_histogram is deprecated and future updates to the Elasticsearch client
+	// will necessitate a migration to either fixed_interval or calendar_interval.
+	source["date_histogram"] = opts
+
+	if a.field != "" {
+		opts["field"] = a.field
+	}
+	if s := a.interval; s != "" {
+		opts["interval"] = s
+	}
+	if a.minDocCount != nil {
+		opts["min_doc_count"] = *a.minDocCount
+	}
+
+	if len(a.subMetricsAggregations) > 0 {
+		aggsMap := make(map[string]interface{})
+		source["aggs"] = aggsMap
+		for _, subAggs := range a.subMetricsAggregations {
+			src, err := subAggs.Source()
+			if err != nil {
+				return nil, err
+			}
+			aggsMap[subAggs.name] = src
+		}
+	}
+
+	return source, nil
+}

--- a/official/v7/querybuilders/search_queries_aggs_bucket_terms.go
+++ b/official/v7/querybuilders/search_queries_aggs_bucket_terms.go
@@ -1,0 +1,95 @@
+package querybuilders
+
+var showTermDocCountError bool = true
+
+// BucketTermsAggregation is a multi-bucket value source based aggregation
+// where buckets are dynamically built - one per unique value.
+//
+// See: http://www.elastic.co/guide/en/elasticsearch/reference/7.0/search-aggregations-bucket-terms-aggregation.html
+type BucketTermsAggregation struct {
+	name                   string
+	field                  string
+	subMetricsAggregations []MetricAggregation
+	size                   *int  //optional
+	minDocCount            *int  //optional
+	showTermDocCountError  *bool //always true
+}
+
+// NewBucketTermsAggregation returns a pointer to a new BucketTermsAggregation
+// with showTermDocCountError always true and an empty subMetricsAggregations list
+func NewBucketTermsAggregation(name, field string) *BucketTermsAggregation {
+	return &BucketTermsAggregation{
+		name:                   name,
+		field:                  field,
+		subMetricsAggregations: make([]MetricAggregation, 0),
+		showTermDocCountError:  &showTermDocCountError,
+	}
+}
+
+// SubMetrics appends a MetricAggregation list to the subMetricsAggregations field
+func (a *BucketTermsAggregation) SubMetrics(
+	aggs ...MetricAggregation,
+) *BucketTermsAggregation {
+	a.subMetricsAggregations = append(a.subMetricsAggregations, aggs...)
+	return a
+}
+
+// Size sets the size field of the BucketTermsAggregation
+func (a *BucketTermsAggregation) Size(size int) *BucketTermsAggregation {
+	a.size = &size
+	return a
+}
+
+// MinDocCount sets the minimum document count per bucket.
+// Buckets with less documents than this min value will not be returned.
+func (a *BucketTermsAggregation) MinDocCount(minDocCount int) *BucketTermsAggregation {
+	a.minDocCount = &minDocCount
+	return a
+}
+
+// Source is a helper function used to build elastic query
+// it returns a map that can be marshalled into json string
+func (a *BucketTermsAggregation) Source() (interface{}, error) {
+	// This is the output of the source function:
+	// It returns the json string that can be used in elastic query
+	// Example:
+	//	{
+	//    "aggs" : {
+	//      "genders" : {
+	//        "terms" : { "field" : "gender" }
+	//      }
+	//    }
+	//	}
+	// This method returns only the { "terms" : { "field" : "gender" } } part.
+
+	source := make(map[string]interface{})
+	opts := make(map[string]interface{})
+	source["terms"] = opts
+
+	if a.field != "" {
+		opts["field"] = a.field
+	}
+	if a.size != nil && *a.size >= 0 {
+		opts["size"] = *a.size
+	}
+	if a.minDocCount != nil && *a.minDocCount >= 0 {
+		opts["min_doc_count"] = *a.minDocCount
+	}
+	if a.showTermDocCountError != nil {
+		opts["show_term_doc_count_error"] = *a.showTermDocCountError
+	}
+
+	if len(a.subMetricsAggregations) > 0 {
+		aggsMap := make(map[string]interface{})
+		source["aggs"] = aggsMap
+		for _, subAggs := range a.subMetricsAggregations {
+			src, err := subAggs.Source()
+			if err != nil {
+				return nil, err
+			}
+			aggsMap[subAggs.name] = src
+		}
+	}
+
+	return source, nil
+}

--- a/official/v7/querybuilders/search_queries_aggs_metrics.go
+++ b/official/v7/querybuilders/search_queries_aggs_metrics.go
@@ -1,0 +1,55 @@
+package querybuilders
+
+// MetricAggregation is a single-value metrics aggregation that operates on
+// numeric values that are extracted from the aggregated documents.
+// These values are extracted from specific numeric fields in the documents
+// See: https://www.elastic.co/guide/en/elasticsearch/reference/7.0/search-aggregations-metrics.html
+type MetricAggregation struct {
+	name      string
+	field     string
+	operation string
+}
+
+// NewMinAggregation creates a new min metric aggregation
+func NewMinAggregation(name, field string) MetricAggregation {
+	return MetricAggregation{name, field, "min"}
+}
+
+// NewSumAggregation creates a new sum metric aggregation
+func NewSumAggregation(name, field string) MetricAggregation {
+	return MetricAggregation{name, field, "sum"}
+}
+
+// NewMaxAggregation creates a new max metric aggregation
+func NewMaxAggregation(name, field string) MetricAggregation {
+	return MetricAggregation{name, field, "max"}
+}
+
+// NewCountAggregation creates a new count metric aggregation
+func NewCountAggregation(name, field string) MetricAggregation {
+	return MetricAggregation{name, field, "value_count"}
+}
+
+// Source is a helper function used to build elastic query
+// it returns a map that can be marshalled into json string
+func (a *MetricAggregation) Source() (interface{}, error) {
+	// This is the output of the source function:
+	// It returns the json string that can be used in elastic query
+	// Example:
+	//	{
+	//    "aggs" : {
+	//      "intraday_return" : { "operation" : { "field" : "change" } }
+	//    }
+	//	}
+	// This method returns only the { "operation" : { "field" : "change" } } part.
+
+	source := make(map[string]interface{})
+	opts := make(map[string]interface{})
+	source[a.operation] = opts
+
+	if a.field != "" {
+		opts["field"] = a.field
+	}
+
+	return source, nil
+}


### PR DESCRIPTION
This commit introduces aggregation support to the search function using the official Elasticsearch client. To request an aggregation, create a `RequestAggregation` within the `SearchConfig` struct before calling the `Search` method.

Supported aggregation types and their Elasticsearch equivalents:

- Metrics `sum` -> `sum`
`min` -> `min`
`max` -> `max`
`count` -> `value_count`

- Buckets `term` -> `terms`
`monthlyhistogram` -> `date_histogram` (fixed interval: month)

It is possible to nest metric aggregations within bucket aggregations. However, this library does not currently support sub-bucket aggregations.

Please note that while Elasticsearch offers various interval options for `date_histogram`, this library is restricted to "month" intervals.

Additionally, although the `minDocCount` and `size` parameters are present in bucket aggregations, they cannot currently be configured through the `SearchConfig` struct, because they are not required for our current use case.

The `date_histogram` aggregation is deprecated in Elasticsearch. Future updates to the Elasticsearch client will necessitate a migration to either `fixed_interval` or `calendar_interval`.

The parsing of the aggregation response is not implemented in this commit and will be addressed in a future pull request.