### PR TITLE
fix: correct response parsing in official/v7

### DIFF
--- a/official/v7/entity_response.go
+++ b/official/v7/entity_response.go
@@ -64,6 +64,11 @@ func parseResponse(ctx context.Context, response *esapi.Response) (SearchRespons
 		return searchResponse, errors.E(op, err, ErrCodeBadGateway)
 	}
 
+	searchResponse.Aggregations, err = parseAggregations(r.Aggregations)
+	if err != nil {
+		return SearchResponse{}, errors.E(op, err)
+	}
+
 	if len(r.Hits.Hits) < 1 {
 		return searchResponse, nil
 	}
@@ -78,11 +83,6 @@ func parseResponse(ctx context.Context, response *esapi.Response) (SearchRespons
 	}
 
 	searchResponse.Paginator = paginator
-
-	searchResponse.Aggregations, err = parseAggregations(r.Aggregations)
-	if err != nil {
-		return SearchResponse{}, errors.E(op, err)
-	}
 
 	return searchResponse, nil
 }


### PR DESCRIPTION
Aggregation parsing was being performed after checking for the existence of the hits field. If the field was missing, parsing would stop. However, in the case of aggregations, the hits field is not present, so the flow would never reach the aggregation parsing logic.