### PR TITLE
fix: adiciona informação de elastic shards no contexto

### DIFF
--- a/official/v7/helper_log.go
+++ b/official/v7/helper_log.go
@@ -33,6 +33,8 @@ func enrichLogWithShards(ctx context.Context, shards int) {
 	log.Ctx(ctx).UpdateContext(func(zc zerolog.Context) zerolog.Context {
 		return zc.Int("elastic_shards", shards)
 	})
+
+	contextmap.Ctx(ctx).Set("elastic_shards", shards)
 }
 
 func truncate(str string, size int) string {


### PR DESCRIPTION
Assim como temos a informação de elastic indexes no contexto, é interessante também colocarmos a informação de elastic shards.